### PR TITLE
adding returning visitors, os, browsers on the dashboard

### DIFF
--- a/web/controllers/metric_detail.py
+++ b/web/controllers/metric_detail.py
@@ -64,6 +64,109 @@ class MetricData():
     def report_domains(self, args):
         return self.get_site_hostnames(args.get('token'))
 
+    def report_returning_visitors(self, args):
+
+        s = self.Session()
+        since = datetime.utcnow() - timedelta(30)
+        until = datetime.utcnow()
+        token = args.get('token')
+        domain = args.get('domain')
+        options = {
+            'site_key': token,
+            'since': since,
+            'until': until,
+            'domain': domain,
+        }
+
+        query = '''
+        SELECT extract(epoch from date_trunc('day', ts)) AS day,
+        count(message->>'returning_from_ts')
+        FROM messages WHERE
+        message->>'returning_from_ts' is not null AND
+        message->>'type' ='site_visit_by_day' AND
+        site_id = (SELECT site_id FROM sites WHERE site_key = :site_key) AND
+        message->>'p' LIKE :domain AND
+        ts >= :since AND
+        ts < :until
+        GROUP BY
+        day;
+        '''
+
+        grouped_counts = s.execute(query,options).fetchall()
+        return [[int(ts), count] for ts, count in grouped_counts]
+
+    def report_os(self, args):
+
+        s = self.Session()
+        token = args.get('token')
+
+        options = {
+            'site_key': token
+        }
+
+        query = '''
+        select message->>'os' as os, count(1) as count
+        from messages WHERE
+        message->>'os' is not null AND
+        message->>'type'='new_year' AND
+        site_id = (SELECT site_id FROM sites WHERE site_key = :site_key)
+        GROUP BY os
+        ORDER BY count DESC
+        LIMIT 5
+        '''
+
+        grouped_counts = s.execute(query,options).fetchall()
+
+        return [[ua, count] for ua, count in grouped_counts]
+
+    def report_ua(self, args):
+
+        s = self.Session()
+        token = args.get('token')
+
+        options = {
+            'site_key': token
+        }
+
+        query = '''
+        select message->>'browser' as browser, count(1) as count
+        from messages WHERE
+        message->>'browser' is not null AND
+        message->>'type'='new_year' AND
+        site_id = (SELECT site_id FROM sites WHERE site_key = :site_key)
+        GROUP BY browser
+        ORDER BY count DESC
+        LIMIT 5
+        '''
+
+        grouped_counts = s.execute(query,options).fetchall()
+
+        return [[ua, count] for ua, count in grouped_counts]
+
+    def report_top_pages(self, args):
+
+        s = self.Session()
+        token = args.get('token')
+        domain = 'http%://' + args.get('domain') + '%'
+        options = {
+            'site_key': token,
+            'domain': domain
+        }
+
+        query = '''
+        select message->>'p' as p, count(1) as count
+        from messages WHERE
+        message->>'type'='page_visit_by_year' AND
+        message->>'p' LIKE :domain AND
+        site_id = (SELECT site_id FROM sites WHERE site_key = :site_key)
+        GROUP BY p
+        ORDER BY count DESC
+        LIMIT 5
+        '''
+
+        grouped_counts = s.execute(query,options).fetchall()
+
+        return [[ua, count] for ua, count in grouped_counts]
     def messages_per_interval(self, token, message_type,
             interval_size='day',
             domain=None):
@@ -101,6 +204,7 @@ class MetricData():
 
         grouped_counts = s.execute(query, options).fetchall()
 
+        print grouped_counts
         return [[int(ts), count] for ts, count in grouped_counts]
 
     def get_site_hostnames(self, token, since=datetime.utcnow() - timedelta(30),

--- a/web/static/dashboard.js
+++ b/web/static/dashboard.js
@@ -35,7 +35,7 @@ $(function () {
                     show: true,
                     barWidth: (response.period == 'daily' ? 24 * 60 * 60 * 1000 : 24 * 60 * 60 * 7 * 1000),
                     fillColor: green,
-                    lineWidth: 1,
+                    lineWidth: 0,
                     align: "center",
                 };
 
@@ -51,6 +51,30 @@ $(function () {
                     timestamp_element.html(original_ts_value);
                 }
             });
+        });
+
+//        e.click(function() {
+//            window.location = "/metric_konark/" + e.data('metric') + '/';
+//        })
+    });
+
+
+    $("div.tabular").each(function (index, elem) {
+        var e = $(elem);
+
+       var url = "/metric_details?token=" + token + "&name=" + e.data('metric') + "&domain=" + site;
+        //var url = "http://192.168.5.239/dashboard_json_files/" + e.data('metric') + ".json";
+        //var url = "konark.php?url=http://192.168.5.239/dashboard_json_files/" + e.data('metric') + ".json";
+        $.getJSON(url, function(response) {
+            console.log(response);
+            // table = `<table>`;
+            table = '';
+            response.data.forEach( e => {
+                table += `<b>${e[0]} :</b> ${e[1]}<br/>`;
+            });
+
+            // table += `</table>`;
+            e.html(table);
         });
 
 //        e.click(function() {

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -72,6 +72,55 @@
             <div class="sparkline" id="1" data-metric="page_load" style="padding: 0px;"></div>
           </div>
         </div>
+
+
+        <div class='dashboard-index'>
+          <div class="metric has-sparkline">
+            <h3>Daily Returning Visitors</h3>
+            <div>
+              <div class="value">
+              -
+              </div>
+              <div class="timestamp">Total</div>
+            </div>
+
+
+            <div class="sparkline" id="1" data-metric="returning_visitors" style="padding: 0px;"></div>
+          </div>
+        </div>
+
+        <div class='dashboard-index'>
+          <div class="metric has-sparkline">
+            <h3>Top Pages</h3>
+            <div>
+              <div class="tabular"  data-metric="top_pages">
+              -
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class='dashboard-index'>
+          <div class="metric has-sparkline">
+            <h3>OS</h3>
+            <div>
+              <div class="tabular"  data-metric="os">
+              -
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class='dashboard-index'>
+          <div class="metric has-sparkline">
+            <h3>Browsers</h3>
+            <div>
+              <div class="tabular"  data-metric="ua">
+              -
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -42,9 +42,6 @@
             <div class="sparkline" id="1" data-metric="site_uv" style="padding: 0px;"></div>
           </div>
 
-        </div>
-
-        <div class='dashboard-index'>
           <div class="metric has-sparkline">
             <h3>Site loads</h3>
             <div>
@@ -58,7 +55,6 @@
             <div class="sparkline" id="1" data-metric="site_visits" style="padding: 0px;"></div>
           </div>
 
-        <div class='dashboard-index'>
           <div class="metric has-sparkline">
             <h3>Page views</h3>
             <div>
@@ -71,10 +67,6 @@
 
             <div class="sparkline" id="1" data-metric="page_load" style="padding: 0px;"></div>
           </div>
-        </div>
-
-
-        <div class='dashboard-index'>
           <div class="metric has-sparkline">
             <h3>Daily Returning Visitors</h3>
             <div>
@@ -89,23 +81,12 @@
           </div>
         </div>
 
-        <div class='dashboard-index'>
-          <div class="metric has-sparkline">
-            <h3>Top Pages</h3>
-            <div>
-              <div class="tabular"  data-metric="top_pages">
-              -
-              </div>
-            </div>
-          </div>
-        </div>
 
         <div class='dashboard-index'>
           <div class="metric has-sparkline">
             <h3>OS</h3>
             <div>
               <div class="tabular"  data-metric="os">
-              -
               </div>
             </div>
           </div>
@@ -116,6 +97,16 @@
             <h3>Browsers</h3>
             <div>
               <div class="tabular"  data-metric="ua">
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class='dashboard-index'>
+          <div class="metric has-sparkline">
+            <h3>Top Pages</h3>
+            <div>
+              <div class="tabular"  data-metric="top_pages">
               -
               </div>
             </div>

--- a/web/templates/template_landing.html
+++ b/web/templates/template_landing.html
@@ -164,7 +164,7 @@ window.onload = function() {
 
 
   <h4>Accessing Dashboard</h4>
-  <p> <a href='#'>{{ context.dashboard }}?token={{ context.site_key }}</a> ,
+  <p> <a href="{{ context.dashboard }}?token={{ context.site_key }}">{{ context.dashboard }}?token={{ context.site_key }}</a> ,
     <br/>If you lose this link, you will have to regenerate the tokens.
   <p class="important">
     <p><a href="{{ context.dashboard }}?token={{ context.site_key }}" rel="sidebar" title="Dashboard Green Analytics">Dashboard Token: {{ context.site_key }}</a></p>


### PR DESCRIPTION
For now issuing a query for each metric, once we have the list of final queries, should follow the structure which @sammacbeth created.

Dashboard needs to have multiple charts, like line graphs, tabular data etc.